### PR TITLE
Adjusting cloud blocktypes to be 18.10 compatible

### DIFF
--- a/blocktype/box/lib.php
+++ b/blocktype/box/lib.php
@@ -29,7 +29,7 @@ class PluginBlocktypeBox extends PluginBlocktypeCloud {
         return array('external');
     }
 
-    public static function render_instance(BlockInstance $instance, $editing=false) {
+    public static function render_instance(BlockInstance $instance, $editing=false, $versioning=false) {
         $configdata = $instance->get('configdata');
         $viewid     = $instance->get('view');
         
@@ -85,7 +85,7 @@ class PluginBlocktypeBox extends PluginBlocktypeCloud {
         return true;
     }
 
-    public static function instance_config_form($instance) {
+    public static function instance_config_form(BlockInstance $instance) {
         global $USER;
         $instanceid = $instance->get('id');
         $configdata = $instance->get('configdata');
@@ -287,7 +287,7 @@ class PluginBlocktypeBox extends PluginBlocktypeCloud {
 
     }
 
-    public static function save_config_options($form, $values) {
+    public static function save_config_options(Pieform $form, $values) {
         set_config_plugin('blocktype', 'box', 'consumerkey', $values['consumerkey']);
         set_config_plugin('blocktype', 'box', 'consumersecret', $values['consumersecret']);
     }

--- a/blocktype/dropbox/lib.php
+++ b/blocktype/dropbox/lib.php
@@ -29,7 +29,7 @@ class PluginBlocktypeDropbox extends PluginBlocktypeCloud {
         return array('external');
     }
 
-    public static function render_instance(BlockInstance $instance, $editing=false) {
+    public static function render_instance(BlockInstance $instance, $editing=false, $versioning=false) {
         $configdata = $instance->get('configdata');
         $viewid     = $instance->get('view');
         
@@ -61,7 +61,7 @@ class PluginBlocktypeDropbox extends PluginBlocktypeCloud {
         return true;
     }
 
-    public static function instance_config_form($instance) {
+    public static function instance_config_form(BlockInstance $instance) {
         global $USER;
         $instanceid = $instance->get('id');
         $configdata = $instance->get('configdata');
@@ -226,7 +226,7 @@ class PluginBlocktypeDropbox extends PluginBlocktypeCloud {
 
     }
 
-    public static function save_config_options($form, $values) {
+    public static function save_config_options(Pieform $form, $values) {
         set_config_plugin('blocktype', 'dropbox', 'consumerkey', $values['consumerkey']);
         set_config_plugin('blocktype', 'dropbox', 'consumersecret', $values['consumersecret']);
     }

--- a/blocktype/googledrive/lib.php
+++ b/blocktype/googledrive/lib.php
@@ -29,7 +29,7 @@ class PluginBlocktypeGoogledrive extends PluginBlocktypeCloud {
         return array('external');
     }
 
-    public static function render_instance(BlockInstance $instance, $editing=false) {
+    public static function render_instance(BlockInstance $instance, $editing=false, $versioning=false) {
         $configdata = $instance->get('configdata');
         $viewid     = $instance->get('view');
         
@@ -82,7 +82,7 @@ class PluginBlocktypeGoogledrive extends PluginBlocktypeCloud {
         return true;
     }
 
-    public static function instance_config_form($instance) {
+    public static function instance_config_form(BlockInstance $instance) {
         global $USER;
         $instanceid = $instance->get('id');
         $configdata = $instance->get('configdata');
@@ -305,7 +305,7 @@ class PluginBlocktypeGoogledrive extends PluginBlocktypeCloud {
 
     }
 
-    public static function save_config_options($form, $values) {
+    public static function save_config_options(Pieform $form, $values) {
         set_config_plugin('blocktype', 'googledrive', 'consumerkey', $values['consumerkey']);
         set_config_plugin('blocktype', 'googledrive', 'consumersecret', $values['consumersecret']);
     }

--- a/blocktype/microsoftdrive/lib.php
+++ b/blocktype/microsoftdrive/lib.php
@@ -29,7 +29,7 @@ class PluginBlocktypeMicrosoftdrive extends PluginBlocktypeCloud {
         return array('external');
     }
 
-    public static function render_instance(BlockInstance $instance, $editing=false) {
+    public static function render_instance(BlockInstance $instance, $editing=false, $versioning=false) {
         $configdata = $instance->get('configdata');
         $viewid     = $instance->get('view');
         
@@ -79,7 +79,7 @@ class PluginBlocktypeMicrosoftdrive extends PluginBlocktypeCloud {
         return true;
     }
 
-    public static function instance_config_form($instance) {
+    public static function instance_config_form(BlockInstance $instance) {
         global $USER;
         $instanceid = $instance->get('id');
         $configdata = $instance->get('configdata');
@@ -259,7 +259,7 @@ class PluginBlocktypeMicrosoftdrive extends PluginBlocktypeCloud {
 
     }
 
-    public static function save_config_options($form, $values) {
+    public static function save_config_options(Pieform $form, $values) {
         set_config_plugin('blocktype', 'microsoftdrive', 'consumerkey', $values['consumerkey']);
         set_config_plugin('blocktype', 'microsoftdrive', 'consumersecret', $values['consumersecret']);
     }

--- a/blocktype/microsoftdrivebiz/lib.php
+++ b/blocktype/microsoftdrivebiz/lib.php
@@ -29,7 +29,7 @@ class PluginBlocktypeMicrosoftdrivebiz extends PluginBlocktypeCloud {
         return array('external');
     }
 
-    public static function render_instance(BlockInstance $instance, $editing=false) {
+    public static function render_instance(BlockInstance $instance, $editing=false, $versioning=false) {
         $configdata = $instance->get('configdata');
         $viewid     = $instance->get('view');
         
@@ -52,7 +52,7 @@ class PluginBlocktypeMicrosoftdrivebiz extends PluginBlocktypeCloud {
         return true;
     }
 
-    public static function instance_config_form($instance) {
+    public static function instance_config_form(BlockInstance $instance) {
         global $USER;
         $instanceid = $instance->get('id');
         $configdata = $instance->get('configdata');
@@ -230,7 +230,7 @@ class PluginBlocktypeMicrosoftdrivebiz extends PluginBlocktypeCloud {
 
     }
 
-    public static function save_config_options($form, $values) {
+    public static function save_config_options(Pieform $form, $values) {
         set_config_plugin('blocktype', 'microsoftdrivebiz', 'consumerkey', $values['consumerkey']);
         set_config_plugin('blocktype', 'microsoftdrivebiz', 'consumersecret', $values['consumersecret']);
     }

--- a/blocktype/owncloud/lib.php
+++ b/blocktype/owncloud/lib.php
@@ -29,7 +29,7 @@ class PluginBlocktypeOwncloud extends PluginBlocktypeCloud {
         return array('external');
     }
 
-    public static function render_instance(BlockInstance $instance, $editing=false) {
+    public static function render_instance(BlockInstance $instance, $editing=false, $versioning=false) {
         $configdata = $instance->get('configdata');
         $viewid     = $instance->get('view');
         
@@ -57,7 +57,7 @@ class PluginBlocktypeOwncloud extends PluginBlocktypeCloud {
         return true;
     }
 
-    public static function instance_config_form($instance) {
+    public static function instance_config_form(BlockInstance $instance) {
         global $USER;
         $instanceid = $instance->get('id');
         $configdata = $instance->get('configdata');
@@ -196,7 +196,7 @@ class PluginBlocktypeOwncloud extends PluginBlocktypeCloud {
 
     }
 
-    public static function save_config_options($form, $values) {
+    public static function save_config_options(Pieform $form, $values) {
         // Strip last slash character if there is any and then add it.
         // This is the only way to be sure it really exists!
         $webdavurl = rtrim($values['webdavurl'], '/') . '/';

--- a/blocktype/picasa/lib.php
+++ b/blocktype/picasa/lib.php
@@ -29,7 +29,7 @@ class PluginBlocktypePicasa extends PluginBlocktypeCloud {
         return array('external');
     }
 
-    public static function render_instance(BlockInstance $instance, $editing=false) {
+    public static function render_instance(BlockInstance $instance, $editing=false, $versioning=false) {
         $configdata = $instance->get('configdata');
         $viewid     = $instance->get('view');
         
@@ -102,7 +102,7 @@ class PluginBlocktypePicasa extends PluginBlocktypeCloud {
         return true;
     }
 
-    public static function instance_config_form($instance) {
+    public static function instance_config_form(BlockInstance $instance) {
         global $USER;
         $instanceid = $instance->get('id');
         $configdata = $instance->get('configdata');
@@ -328,7 +328,7 @@ class PluginBlocktypePicasa extends PluginBlocktypeCloud {
 
     }
 
-    public static function save_config_options($form, $values) {
+    public static function save_config_options(Pieform $form, $values) {
         set_config_plugin('blocktype', 'picasa', 'consumerkey', $values['consumerkey']);
         set_config_plugin('blocktype', 'picasa', 'consumersecret', $values['consumersecret']);
     }

--- a/blocktype/zotero/lib.php
+++ b/blocktype/zotero/lib.php
@@ -29,7 +29,7 @@ class PluginBlocktypeZotero extends PluginBlocktypeCloud {
         return array('external');
     }
 
-    public static function render_instance(BlockInstance $instance, $editing=false) {
+    public static function render_instance(BlockInstance $instance, $editing=false, $versioning=false) {
         $configdata = $instance->get('configdata');
         $viewid     = $instance->get('view');
         
@@ -104,7 +104,7 @@ class PluginBlocktypeZotero extends PluginBlocktypeCloud {
         return array('js/configform.js');
     }
 
-    public static function instance_config_form($instance) {
+    public static function instance_config_form(BlockInstance $instance) {
         global $USER;
         $instanceid = $instance->get('id');
         $configdata = $instance->get('configdata');
@@ -270,7 +270,7 @@ class PluginBlocktypeZotero extends PluginBlocktypeCloud {
 
     }
 
-    public static function save_config_options($form, $values) {
+    public static function save_config_options(Pieform $form, $values) {
         set_config_plugin('blocktype', 'zotero', 'consumerkey', $values['consumerkey']);
         set_config_plugin('blocktype', 'zotero', 'consumersecret', $values['consumersecret']);
     }


### PR DESCRIPTION
Now that we have a $versioning option
